### PR TITLE
Update EVEWindow.cs

### DIFF
--- a/EVEWindow.cs
+++ b/EVEWindow.cs
@@ -125,7 +125,27 @@ namespace EVE.ISXEVE
 		{
 			get { return this.GetString("Text"); }
 		}
-
+		/// <summary>
+        	/// how many buttons are  in the window 
+		/// </summary>
+		public int NumButtons
+		{
+		    get { return this.GetInt("NumButtons"); }
+		}
+		/// <summary>
+		/// give button object for name: like "ok", "Accept"...
+		/// </summary>
+		public EVEUIButton Button(string buttonName)
+		{
+		    return new EVEUIButton(GetMember("Button", buttonName));
+		}
+		/// <summary>
+		/// give button object for nummber in NumButtons : "1", "2", "3"...
+		/// </summary>
+		public EVEUIButton Button(int i)
+		{
+		    return new EVEUIButton(GetMember("Button", i.ToString(CultureInfo.CurrentCulture)));      
+		}
 
 		#endregion
 


### PR DESCRIPTION
February 16, 2021
[20210209.0007]
* The "NumButtons" and "Button" MEMBERS of the 'eveagentdialogwindow' datatype have been moved to the parent datatype 'evewindow'.  Also,
  please note that these MEMBERS will only return data regarding buttons that are enabled and visible.