### PR TITLE
Update IEve.cs

### DIFF
--- a/Interfaces/IEve.cs
+++ b/Interfaces/IEve.cs
@@ -67,7 +67,7 @@ namespace EVE.ISXEVE.Interfaces
 		/// Returns the number of chat channels currently open in your UI
 		/// </summary>
 		/// <returns></returns>
-		Int32 NumOpenChannels { get; }
+		Int32 ChatChannelCount { get; }
 
 		/// <summary>
 		/// Returns a list of the "SystemIDs" of the systems along your current destination (autopilot) route.


### PR DESCRIPTION
updated NumbOpenChannels to ChatChannelCount based on the January 29, 2012 [ISXEVE-20120124.0121] changelog showing that NumOpenChannels -> ChatChannelCount was a renamed method.